### PR TITLE
Fix indentation and alignment of lines 94 and 95

### DIFF
--- a/nml_tools/nml2swc/nml2swc.py
+++ b/nml_tools/nml2swc/nml2swc.py
@@ -91,8 +91,8 @@ def write_swc(nmls_path, radius=0):
             n += 1
             if node_id in child_list:
                 node_parent = child_parent[child_list.index(node_id)][1]
-	    else:
-	        node_parent = -1
+            else:
+                node_parent = -1
 
         f = open(swc, 'w')
         for line in lines_to_write:


### PR DESCRIPTION
While the previous commit replaced some horizontal tabs with sets of
spaces, it did not replace all of them. Further, the else statement on
line 94 remained misaligned with the preceding if statement on line 92.
As a result, the code failed to run. This fixes both the inconsistent
indentation style and the misaligned conditional statements.